### PR TITLE
feat: Add initial deployment pipeline

### DIFF
--- a/src/LogLambda/index.js
+++ b/src/LogLambda/index.js
@@ -1,5 +1,5 @@
 async function handler(event, context) {
-    console.log(event);
+    console.log(JSON.stringify(event));
     console.log(context);
 };
 

--- a/src/MonitoringTargetStage.ts
+++ b/src/MonitoringTargetStage.ts
@@ -21,8 +21,8 @@ export class MonitoringTargetStage extends Stage {
     Tags.of(this).add('cdkManaged', 'yes');
     Tags.of(this).add('Project', Statics.projectName);
     props.deployToEnvironments.forEach(environment => {
-      new MonitoringTargetStack(this, `monitoring-${environment.name}`, { env: environment.env});
-    })
+      new MonitoringTargetStack(this, `monitoring-${environment.name}`, { env: environment.env });
+    });
   }
 }
 

--- a/src/MonitoringTargetStage.ts
+++ b/src/MonitoringTargetStage.ts
@@ -20,8 +20,9 @@ export class MonitoringTargetStage extends Stage {
     super(scope, id, props);
     Tags.of(this).add('cdkManaged', 'yes');
     Tags.of(this).add('Project', Statics.projectName);
-
-    new MonitoringTargetStack(this, 'monitoring');
+    props.deployToEnvironments.forEach(environment => {
+      new MonitoringTargetStack(this, `monitoring-${environment.name}`, { env: environment.env});
+    })
   }
 }
 

--- a/src/MonitoringTargetStage.ts
+++ b/src/MonitoringTargetStage.ts
@@ -1,10 +1,14 @@
 import path from 'path';
-import { aws_sns, aws_ssm, Duration, Stack, StackProps, Stage, StageProps, Tags } from 'aws-cdk-lib';
+import { aws_sns, aws_ssm, Duration, Environment, Stack, StackProps, Stage, StageProps, Tags } from 'aws-cdk-lib';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { LambdaSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
 import { Construct } from 'constructs';
 import { Statics } from './statics';
+
+export interface MonitoringTargetStageProps extends StageProps {
+  deployToEnvironments: { name: string; env: Environment }[];
+}
 
 export class MonitoringTargetStage extends Stage {
   /**
@@ -12,7 +16,7 @@ export class MonitoringTargetStage extends Stage {
 	 * a monitoring topic, which can be used account-wide as a target
 	 * for monitoring notifications.
 	 */
-  constructor(scope: Construct, id: string, props: StageProps) {
+  constructor(scope: Construct, id: string, props: MonitoringTargetStageProps) {
     super(scope, id, props);
     Tags.of(this).add('cdkManaged', 'yes');
     Tags.of(this).add('Project', Statics.projectName);

--- a/src/PipelineStack.ts
+++ b/src/PipelineStack.ts
@@ -5,7 +5,7 @@ import { Statics } from './statics';
 
 export interface PipelineStackProps extends StackProps{
   branchName: string;
-  deployToEnvironment: Environment;
+  deployToEnvironments: { name: string; env: Environment }[];
   environmentName: string;
 }
 
@@ -23,7 +23,7 @@ export class PipelineStack extends Stack {
     const source = this.connectionSource(connectionArn);
 
     const pipeline = this.pipeline(source);
-    pipeline.addStage(new MonitoringTargetStage(this, 'monitoring-stack', { env: props.deployToEnvironment }));
+    pipeline.addStage(new MonitoringTargetStage(this, 'monitoring-stack', { deployToEnvironments: props.deployToEnvironments }));
   }
 
   pipeline(source: pipelines.CodePipelineSource): pipelines.CodePipeline {

--- a/src/PipelineStack.ts
+++ b/src/PipelineStack.ts
@@ -23,7 +23,7 @@ export class PipelineStack extends Stack {
     const source = this.connectionSource(connectionArn);
 
     const pipeline = this.pipeline(source);
-    pipeline.addStage(new MonitoringTargetStage(this, 'monitoring-parameters', { env: props.deployToEnvironment }));
+    pipeline.addStage(new MonitoringTargetStage(this, 'monitoring-stack', { env: props.deployToEnvironment }));
   }
 
   pipeline(source: pipelines.CodePipelineSource): pipelines.CodePipeline {

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ if ('BRANCH_NAME' in process.env == false || process.env.BRANCH_NAME == 'develop
       env: deploymentEnvironment,
       branchName: 'development',
       deployToEnvironment: sandboxEnvironment,
+			environmentName: 'sandbox'
     },
   );
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,18 +23,12 @@ const sandboxEnvironment = {
 // };
 
 const app = new App();
-if ('BRANCH_NAME' in process.env == false || process.env.BRANCH_NAME == 'development') {
-  new PipelineStack(app, 'aws-monitoring-pipeline-development',
-    {
-      env: deploymentEnvironment,
-      branchName: 'development',
-      deployToEnvironment: sandboxEnvironment,
-      environmentName: 'sandbox',
-    },
-  );
-}
 
 
+/**
+ * List all environments for which which a monitoring
+ * pipeline should be deployed in prod
+ */
 const deploymentEnvironments = [
   {
     name: 'auth-accp',
@@ -45,26 +39,24 @@ const deploymentEnvironments = [
   },
 ];
 
-if ('BRANCH_NAME' in process.env == false || process.env.BRANCH_NAME == 'main') {
+if ('BRANCH_NAME' in process.env == false || process.env.BRANCH_NAME == 'development') {
   new PipelineStack(app, 'aws-monitoring-pipeline-development',
     {
       env: deploymentEnvironment,
       branchName: 'development',
-      deployToEnvironment: sandboxEnvironment,
+      deployToEnvironments: [{ name: 'sandbox', env: sandboxEnvironment }],
       environmentName: 'sandbox',
     },
   );
 } else if ( process.env.BRANCH_NAME == 'main') {
-  deploymentEnvironments.forEach(environment => {
-    new PipelineStack(app, `aws-monitoring-pipeline-${environment.name}`,
-      {
-        env: deploymentEnvironment,
-        branchName: 'main',
-        deployToEnvironment: environment.env,
-        environmentName: environment.name,
-      },
-    );
-  });
+  new PipelineStack(app, 'aws-monitoring-pipeline-prod',
+    {
+      env: deploymentEnvironment,
+      branchName: 'main',
+      deployToEnvironments: deploymentEnvironments,
+      environmentName: 'production',
+    },
+  );
 }
 
 app.synth();

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,7 @@ const sandboxEnvironment = {
 
 const app = new App();
 if ('BRANCH_NAME' in process.env == false || process.env.BRANCH_NAME == 'development') {
-  new PipelineStack(app, 'mijnuitkering-pipeline-development',
+  new PipelineStack(app, 'aws-monitoring-pipeline-development',
     {
       env: deploymentEnvironment,
       branchName: 'development',

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,13 +3,13 @@ import { PipelineStack } from './PipelineStack';
 
 // for development, use sandbox account
 const deploymentEnvironment = {
-	account: '418648875085',
-	region: 'eu-west-1',
+  account: '418648875085',
+  region: 'eu-west-1',
 };
 
 const sandboxEnvironment = {
-	account: '122467643252',
-	region: 'eu-west-1',
+  account: '122467643252',
+  region: 'eu-west-1',
 };
 
 // const acceptanceEnvironment = {
@@ -24,47 +24,47 @@ const sandboxEnvironment = {
 
 const app = new App();
 if ('BRANCH_NAME' in process.env == false || process.env.BRANCH_NAME == 'development') {
-	new PipelineStack(app, 'aws-monitoring-pipeline-development',
-		{
-			env: deploymentEnvironment,
-			branchName: 'development',
-			deployToEnvironment: sandboxEnvironment,
-			environmentName: 'sandbox'
-		},
-	);
+  new PipelineStack(app, 'aws-monitoring-pipeline-development',
+    {
+      env: deploymentEnvironment,
+      branchName: 'development',
+      deployToEnvironment: sandboxEnvironment,
+      environmentName: 'sandbox',
+    },
+  );
 }
 
 
 const deploymentEnvironments = [
-	{ 
-		name: 'auth-accp',
-		env: {
-			account: '315037222840',
-			region: 'eu-west-1',
-		}
-	}
-]
+  {
+    name: 'auth-accp',
+    env: {
+      account: '315037222840',
+      region: 'eu-west-1',
+    },
+  },
+];
 
 if ('BRANCH_NAME' in process.env == false || process.env.BRANCH_NAME == 'main') {
-	new PipelineStack(app, 'aws-monitoring-pipeline-development',
-		{
-			env: deploymentEnvironment,
-			branchName: 'development',
-			deployToEnvironment: sandboxEnvironment,
-			environmentName: 'sandbox'
-		},
-	);
+  new PipelineStack(app, 'aws-monitoring-pipeline-development',
+    {
+      env: deploymentEnvironment,
+      branchName: 'development',
+      deployToEnvironment: sandboxEnvironment,
+      environmentName: 'sandbox',
+    },
+  );
 } else if ( process.env.BRANCH_NAME == 'main') {
-	deploymentEnvironments.forEach(environment => {
-		new PipelineStack(app, `aws-monitoring-pipeline-${environment.name}`,
-		{
-			env: deploymentEnvironment,
-			branchName: 'main',
-			deployToEnvironment: environment.env,
-			environmentName: environment.name
-		},
-	);
-	})
+  deploymentEnvironments.forEach(environment => {
+    new PipelineStack(app, `aws-monitoring-pipeline-${environment.name}`,
+      {
+        env: deploymentEnvironment,
+        branchName: 'main',
+        deployToEnvironment: environment.env,
+        environmentName: environment.name,
+      },
+    );
+  });
 }
 
 app.synth();

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,13 +3,13 @@ import { PipelineStack } from './PipelineStack';
 
 // for development, use sandbox account
 const deploymentEnvironment = {
-  account: '418648875085',
-  region: 'eu-west-1',
+	account: '418648875085',
+	region: 'eu-west-1',
 };
 
 const sandboxEnvironment = {
-  account: '122467643252',
-  region: 'eu-west-1',
+	account: '122467643252',
+	region: 'eu-west-1',
 };
 
 // const acceptanceEnvironment = {
@@ -24,13 +24,47 @@ const sandboxEnvironment = {
 
 const app = new App();
 if ('BRANCH_NAME' in process.env == false || process.env.BRANCH_NAME == 'development') {
-  new PipelineStack(app, 'aws-monitoring-pipeline-development',
-    {
-      env: deploymentEnvironment,
-      branchName: 'development',
-      deployToEnvironment: sandboxEnvironment,
+	new PipelineStack(app, 'aws-monitoring-pipeline-development',
+		{
+			env: deploymentEnvironment,
+			branchName: 'development',
+			deployToEnvironment: sandboxEnvironment,
 			environmentName: 'sandbox'
-    },
-  );
+		},
+	);
 }
+
+
+const deploymentEnvironments = [
+	{ 
+		name: 'auth-accp',
+		env: {
+			account: '315037222840',
+			region: 'eu-west-1',
+		}
+	}
+]
+
+if ('BRANCH_NAME' in process.env == false || process.env.BRANCH_NAME == 'main') {
+	new PipelineStack(app, 'aws-monitoring-pipeline-development',
+		{
+			env: deploymentEnvironment,
+			branchName: 'development',
+			deployToEnvironment: sandboxEnvironment,
+			environmentName: 'sandbox'
+		},
+	);
+} else if ( process.env.BRANCH_NAME == 'main') {
+	deploymentEnvironments.forEach(environment => {
+		new PipelineStack(app, `aws-monitoring-pipeline-${environment.name}`,
+		{
+			env: deploymentEnvironment,
+			branchName: 'main',
+			deployToEnvironment: environment.env,
+			environmentName: environment.name
+		},
+	);
+	})
+}
+
 app.synth();


### PR DESCRIPTION
- Setup the pipeline.
- Adds a list of deployment accounts/regions. For each specified account a pipeline based on `main` will be created.