### PR TITLE
feat: add cdk nag

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -94,6 +94,10 @@
       "type": "runtime"
     },
     {
+      "name": "cdk-nag",
+      "type": "runtime"
+    },
+    {
       "name": "constructs",
       "version": "^10.0.5",
       "type": "runtime"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -2,12 +2,15 @@ const { GemeenteNijmegenCdkApp } = require('@gemeentenijmegen/modules-projen');
 const project = new GemeenteNijmegenCdkApp({
   cdkVersion: '2.1.0',
   defaultReleaseBranch: 'main',
-  devDeps: ['@gemeentenijmegen/modules-projen'],
+  devDeps: [
+    '@gemeentenijmegen/modules-projen',
+  ],
   name: 'aws-monitoring',
 
   deps: [
     'aws-cdk-lib',
     'constructs',
+    'cdk-nag',
   ],
   /* Runtime dependencies of this module. */
   // description: undefined,  /* The description is just a string that helps people understand the purpose of the package. */

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "^2.1.0",
+    "cdk-nag": "^2.15.39",
     "constructs": "^10.0.5"
   },
   "license": "EUPL-1.2",

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,5 +1,6 @@
-import { App } from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
+import { App, Aspects, Stack } from 'aws-cdk-lib';
+import { Annotations, Match, Template } from 'aws-cdk-lib/assertions';
+import { AwsSolutionsChecks } from 'cdk-nag';
 import { MonitoringTargetStack } from '../src/MonitoringTargetStage';
 
 test('Snapshot', () => {
@@ -8,4 +9,35 @@ test('Snapshot', () => {
 
   const template = Template.fromStack(stack);
   expect(template.toJSON()).toMatchSnapshot();
+});
+
+describe('cdk-nag AwsSolutions Pack', () => {
+  let app: App;
+  let stack: Stack;
+  beforeAll(() => {
+    // GIVEN
+    app = new App();
+    stack = new MonitoringTargetStack(app, 'test');
+    Aspects.of(stack).add(new AwsSolutionsChecks({ verbose: true }));
+
+    // WHEN
+    Aspects.of(stack).add(new AwsSolutionsChecks());
+  });
+
+  // THEN
+  test('No unsuppressed Warnings', () => {
+    const warnings = Annotations.fromStack(stack).findWarning(
+      '*',
+      Match.stringLikeRegexp('AwsSolutions-.*'),
+    );
+    expect(warnings).toHaveLength(0);
+  });
+
+  test('No unsuppressed Errors', () => {
+    const errors = Annotations.fromStack(stack).findError(
+      '*',
+      Match.stringLikeRegexp('AwsSolutions-.*'),
+    );
+    expect(errors).toHaveLength(0);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1490,6 +1490,11 @@ case@1.6.3, case@^1.6.3:
   resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
   integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
 
+cdk-nag@^2.15.39:
+  version "2.15.39"
+  resolved "https://registry.yarnpkg.com/cdk-nag/-/cdk-nag-2.15.39.tgz#9577da8088f9479d95de4f5043a53b904505fd22"
+  integrity sha512-pdxwPu3ZjmO93eojqeXHhJaHinm/SL9nOwDKfZCkiOkLK7cOG8DwGvXrYs4LksqE8VAcCTNP3EaXpsjnqPLR+Q==
+
 chalk@^2.0.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"


### PR DESCRIPTION
Add cdk nag, test the stack in unit tests.
Adds two suppressions:
- Default lambda execution role (allowed to create log group)
- Log retention custom resource has permissions to set log retention on all resources.