### PR TITLE
feat: Add devopsguru notifications channel, export key arn to parameter store

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -19,7 +19,7 @@ const project = new GemeenteNijmegenCdkApp({
   // description: undefined,  /* The description is just a string that helps people understand the purpose of the package. */
   // packageName: undefined,  /* The "name" in package.json. */
   gitignore: [
-    'src/LogLambda/index.js'
-  ]
+    'src/LogLambda/index.js',
+  ],
 });
 project.synth();

--- a/src/MonitoringTargetStage.ts
+++ b/src/MonitoringTargetStage.ts
@@ -69,6 +69,12 @@ export class MonitoringTargetStack extends Stack {
       'kms:ReEncrypt*',
       'kms:GenerateDataKey*',
     );
+
+    new aws_ssm.StringParameter(this, 'key-arn', {
+      stringValue: key.keyArn,
+      parameterName: Statics.ssmMonitoringKeyArn,
+    });
+
     return key;
   }
 

--- a/src/statics.ts
+++ b/src/statics.ts
@@ -9,9 +9,10 @@ export abstract class Statics {
   static readonly repositoryOwner: string = 'GemeenteNijmegen';
 
   /**
-   * Arn for account-wide monitoring topic
+   * Arn for account-wide monitoring topic and encryption key
    */
   static readonly ssmMonitoringTopicArn: string = '/account/sns/monitoring-topic-arn';
+  static readonly ssmMonitoringKeyArn: string = '/account/kms/monitoring-key-arn';
 
   /**
    * Slack webhook url for monitoring lambda


### PR DESCRIPTION
key-arn-export: Voorbereiding om notificaties vanuit andere projecten te kunnen ontvangen
devopsguru: Accountbrede dienst, hoort hier thuis. Stap 1 van verplaatsing uit webformulieren.