### PR TITLE
fix: temporarily remove notifications channel

### DIFF
--- a/src/MonitoringTargetStage.ts
+++ b/src/MonitoringTargetStage.ts
@@ -193,13 +193,13 @@ class DevopsGuruNotifications extends Construct {
     // },
     // );
 
-    new aws_devopsguru.CfnNotificationChannel(this, 'devopsGuru-notification-channel', {
-      config: {
-        sns: {
-          topicArn: props.topic.topicArn,
-        },
-      },
-    });
+    // new aws_devopsguru.CfnNotificationChannel(this, 'devopsGuru-notification-channel', {
+    //   config: {
+    //     sns: {
+    //       topicArn: props.topic.topicArn,
+    //     },
+    //   },
+    // });
 
     props.topicKey.addToResourcePolicy(new aws_iam.PolicyStatement({
       effect: aws_iam.Effect.ALLOW,


### PR DESCRIPTION
Cloudformation zeurt over het al bestaan van dit channel, ook al verandert er niks aan. verwijderen en weer toevoegen in de stack hielp bij de sandbox. In auth-prod hopelijk geen issue omdat ik het channel daar nog niet aangemaakt had.