### PR TITLE
feat: Exclude noisy alarms

### DIFF
--- a/src/LogLambda/index.ts
+++ b/src/LogLambda/index.ts
@@ -55,6 +55,13 @@ export function messageShouldTriggerAlert(message: any): boolean {
  * @param message an SNS message containing a cloudwatch state changed event
  */
 function cloudwatchAlarmEventShouldTriggerAlert(message: any): boolean {
+  // List of alarms that are too noisy for immediate notifications
+  const excludedAlarms = [
+    'CIS-Unauthorized Activity Attempt',
+  ];
+  if (excludedAlarms.includes(message?.detail?.alarmName)) {
+    return false;
+  }
   const state = message?.detail?.state?.value;
   const previousState = message?.detail?.previousState?.value;
   if (state == 'ALARM' || previousState == 'ALARM') {


### PR DESCRIPTION
- excludes `CIS-Unauthorized Activity Attempt` for now. This alarm triggers for internal AWS services (devopsguru, aws config) which are not relevant.