### PR TITLE
feat: exclude noisy alarms

### DIFF
--- a/src/LogLambda/index.ts
+++ b/src/LogLambda/index.ts
@@ -113,13 +113,11 @@ function slackParamsFromAlarmMessage(message: any): any {
  * @returns {object} a message object
  */
 function slackParamsFromEcsMessage(message: any): any {
-  const containerString = message?.detail?.containers.map((container: { name: any; lastStatus: any }) => `${container.name} (${container.lastStatus})`).join(`
-  - `);
+  const containerString = message?.detail?.containers.map((container: { name: any; lastStatus: any }) => `${container.name} (${container.lastStatus})`).join('\\n - ');
   const clusterName = message?.detail?.clusterArn.split('/').pop();
   let messageObject = {
     title: '',
-    message: `Containers involved:
-    ${containerString}`,
+    message: `Containers involved: \\n - ${containerString}`,
     context: `${getEventType(message)}, cluster ${clusterName}`,
     url: `https://${message?.region}.console.aws.amazon.com/ecs/home?region=${message?.region}#/clusters/${clusterName}/services`,
     url_text: 'Bekijk cluster',

--- a/src/LogLambda/test/alarm.test.ts
+++ b/src/LogLambda/test/alarm.test.ts
@@ -91,7 +91,16 @@ describe('ECS State changes', () => {
     const sampleEventJson = await getStringFromFilePath(path.join('samples', 'ecs-task-state-change.json'));
     const event = JSON.parse(sampleEventJson);
     const message = parseMessageFromEvent(event);
-    expect(slackParamsFromMessage(message).message).toBe('Containers involved:\n    test-sleep (PENDING)');
+    expect(slackParamsFromMessage(message).message).toBe('Containers involved: \\n - test-sleep (PENDING)');
+  });
+
+  test('Get slack message object', async () => {
+    const sampleEventJson = await getStringFromFilePath(path.join('samples', 'ecs-task-state-change.json'));
+    const event = JSON.parse(sampleEventJson);
+    const message = parseMessageFromEvent(event);
+    const params = slackParamsFromMessage(message);
+    const slackMessage = createMessage(params);
+    expect(slackMessage.blocks).toHaveLength(4);
   });
 });
 


### PR DESCRIPTION
Some alarms are too noisy for posting to the notification channel, they result in too many false positives. These are excluded.