### PR TITLE
feat:  Add EC2 instance state changes

### DIFF
--- a/src/DevopsGuruNotifications.ts
+++ b/src/DevopsGuruNotifications.ts
@@ -13,7 +13,6 @@ export class DevopsGuruNotifications extends Construct {
   constructor(scope: Construct, id: string, props: DevopsGuruNotificationsProps) {
     super(scope, id);
 
-    //Enable when we've removed the stack from webformulieren
     new aws_devopsguru.CfnResourceCollection(this, 'CfnResourceCollection', {
       resourceCollectionFilter: {
         cloudFormation: {

--- a/src/LogLambda/MessageFormatter.ts
+++ b/src/LogLambda/MessageFormatter.ts
@@ -78,7 +78,7 @@ export class EcsMessageFormatter extends MessageFormatter {
 
   messageParameters(): messageParameters {
     const message = this.message;
-    const containerString = message?.detail?.containers.map((container: { name: any; lastStatus: any; }) => `${container.name} (${container.lastStatus})`).join('\\n - ');
+    const containerString = message?.detail?.containers.map((container: { name: any; lastStatus: any }) => `${container.name} (${container.lastStatus})`).join('\\n - ');
     const clusterName = message?.detail?.clusterArn.split('/').pop();
     let messageObject = {
       title: '',
@@ -94,6 +94,43 @@ export class EcsMessageFormatter extends MessageFormatter {
     } else {
       messageObject.title = `✅ ECS Task in desired state (${status})`;
     }
+    return messageObject;
+  }
+}
+
+
+export class Ec2MessageFormatter extends MessageFormatter {
+  constructor(message: string) {
+    super(message);
+  }
+
+  messageParameters(): messageParameters {
+    const message = this.message;
+    const status = message?.detail?.state;
+    let messageObject = {
+      title: `EC2 instance ${status}`,
+      message: `Instance id: ${message?.detail?.instanceId}`,
+      context: `${getEventType(message)}`,
+      url: `https://${message?.region}.console.aws.amazon.com/ec2/v2/home?region=${message?.region}#InstanceDetails:instanceId=${message?.detail?.instanceId}`,
+      url_text: 'Bekijk instance',
+    };
+    return messageObject;
+  }
+}
+
+export class UnhandledEventFormatter extends MessageFormatter {
+  constructor(message: string) {
+    super(message);
+  }
+
+  messageParameters(): messageParameters {
+    let messageObject = {
+      title: 'Unhandled event',
+      message: `Monitoring topic received an unhandled event. No message format available. Message: \n\`\`\`${JSON.stringify(this.message)}\`\`\` `,
+      context: 'unhandled event from SNS topic',
+      url: 'https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1',
+      url_text: 'Open CloudWatch',
+    };
     return messageObject;
   }
 }

--- a/src/LogLambda/MessageFormatter.ts
+++ b/src/LogLambda/MessageFormatter.ts
@@ -56,7 +56,7 @@ export class AlarmMessageFormatter extends MessageFormatter {
       title: '',
       message: message?.detail.state.reason,
       context: getEventType(message),
-      url: `https:/${message?.region}.console.aws.amazon.com/cloudwatch/home?region=${message?.region}#alarmsV2:alarm/${encodeURIComponent(message.detail.alarmName)}`,
+      url: `https://${message?.region}.console.aws.amazon.com/cloudwatch/home?region=${message?.region}#alarmsV2:alarm/${encodeURIComponent(message.detail.alarmName)}`,
       url_text: 'Bekijk alarm',
     };
     if (message?.detail?.state?.value == 'ALARM') {


### PR DESCRIPTION
This adds support for notifications from eventbridge ec2 state changes. This is used by rule generated by the documentdb bastionhost.