### PR TITLE
feat: Notify on certificate expiry events

### DIFF
--- a/src/LogLambda/MessageFormatter.ts
+++ b/src/LogLambda/MessageFormatter.ts
@@ -109,9 +109,9 @@ export class Ec2MessageFormatter extends MessageFormatter {
     const status = message?.detail?.state;
     let messageObject = {
       title: `EC2 instance ${status}`,
-      message: `Instance id: ${message?.detail?.instanceId}`,
+      message: `Instance id: ${message?.detail?.['instance-id']}`,
       context: `${getEventType(message)}`,
-      url: `https://${message?.region}.console.aws.amazon.com/ec2/v2/home?region=${message?.region}#InstanceDetails:instanceId=${message?.detail?.instanceId}`,
+      url: `https://${message?.region}.console.aws.amazon.com/ec2/v2/home?region=${message?.region}#InstanceDetails:instanceId=${message?.detail?.['instance-id']}`,
       url_text: 'Bekijk instance',
     };
     return messageObject;

--- a/src/LogLambda/test/alarm.test.ts
+++ b/src/LogLambda/test/alarm.test.ts
@@ -112,6 +112,18 @@ describe('ECS State changes', () => {
 });
 
 
+describe('EC2 State changes', () => {
+  test('Running', async () => {
+    axiosMock.onPost().reply(200, {});
+    const sampleEventJson = await getStringFromFilePath(path.join('samples', 'ec2-instance-state-change.json'));
+    const event = JSON.parse(sampleEventJson);
+    const message = parseMessageFromEvent(event);
+    await sendMessageToSlack(slackMessageFromSNSMessage(message));
+    const data = JSON.parse(axiosMock.history.post[0].data);
+    expect(data?.blocks[2].text.text).toContain('i-0482279efaef0935a');
+  });
+});
+
 async function getStringFromFilePath(filePath: string): Promise<string> {
   return new Promise((res, rej) => {
     fs.readFile(path.join(__dirname, filePath), (err, data) => {

--- a/src/LogLambda/test/samples/ec2-instance-state-change.json
+++ b/src/LogLambda/test/samples/ec2-instance-state-change.json
@@ -1,0 +1,22 @@
+{
+    "Records": [
+        {
+            "EventSource": "aws:sns",
+            "EventVersion": "1.0",
+            "EventSubscriptionArn": "arn:aws:sns:eu-west-1:315037222840:monitoring-stack-monitoring-auth-accp-snstopic2C4AE3C1-1K7VM9XU3WO28:491f4b30-de15-4699-9538-9bda14c9a4b7",
+            "Sns": {
+                "Type": "Notification",
+                "MessageId": "52fc3cb0-d5f9-54bd-a9b5-67cd4bd18220",
+                "TopicArn": "arn:aws:sns:eu-west-1:315037222840:monitoring-stack-monitoring-auth-accp-snstopic2C4AE3C1-1K7VM9XU3WO28",
+                "Subject": null,
+                "Message": "{\"version\":\"0\",\"id\":\"fe2ae20e-91a0-4d18-deff-0b4b3df6c32f\",\"detail-type\":\"EC2 Instance State-change Notification\",\"source\":\"aws.ec2\",\"account\":\"315037222840\",\"time\":\"2022-08-22T15:08:24Z\",\"region\":\"eu-west-1\",\"resources\":[\"arn:aws:ec2:eu-west-1:315037222840:instance/i-0482279efaef0935a\"],\"detail\":{\"instance-id\":\"i-0482279efaef0935a\",\"state\":\"running\"}}",
+                "Timestamp": "2022-08-22T15:08:24.516Z",
+                "SignatureVersion": "1",
+                "Signature": "PJo2mMYrqhdAUbmwkgdJfKCEfVCS8vJnzQrZ7wSK1MixeVYOCUcIKRg+D3q4wqStJWXtgEL3iz4Ibu56J0B8d27tAgMfphqcUYW+eeYcYsD+XwoL8CnWnTWeLbJ/UplR9qmqh9rWLaMk4GYaI7yRR/QWhax2jmtENrD7PXI3son+hGci54mqeX/tcepfaAuvVdl6amTBNodUod41MjJNkeuTmGupg/LgfSebsnVsixtXIEuvXHbMvIPa10XxLJKCiMZec1BLOGYGquhfoeCWFMfaS/Q3t82eRRz7VvjZb3H3VuwLHcUeOCYdpBc/GYLaRsaZQDy3FVg6/VTvVRtAxA==",
+                "SigningCertUrl": "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-56e67fcb41f6fec09b0196692625d385.pem",
+                "UnsubscribeUrl": "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:315037222840:monitoring-stack-monitoring-auth-accp-snstopic2C4AE3C1-1K7VM9XU3WO28:491f4b30-de15-4699-9538-9bda14c9a4b7",
+                "MessageAttributes": {}
+            }
+        }
+    ]
+}

--- a/src/MonitoringTargetStage.ts
+++ b/src/MonitoringTargetStage.ts
@@ -81,6 +81,14 @@ export class MonitoringTargetStack extends Stack {
         },
         ruleDescription: 'Send all ECS state change notifications to SNS',
       },
+      {
+        id: 'certificates',
+        pattern: {
+          source: ['aws.acm'],
+          detailType: ['ACM Certificate Approaching Expiration'],
+        },
+        ruleDescription: 'Send certificate expiration notifications to SNS',
+      },
     ];
 
     eventSubscriptions.forEach(subscription =>


### PR DESCRIPTION
Dit was onderdeel van het webformulieren-project, maar kan op account-niveau geregeld worden.

Daarnaast: fix voor instance-id in EC2 event-bericht, met test.