### PR TITLE
fix: Use correct name for account (without prefix)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -46,7 +46,7 @@ const deploymentEnvironments: DeploymentEnvironment[] = [
     },
   },
   {
-    accountName: 'gemeentenijmegen-dns',
+    accountName: 'dns',
     env: {
       account: '108197740505',
       region: 'eu-west-1',


### PR DESCRIPTION
The cloudtrail loggroup won't be found if I use the wrong name.