### PR TITLE
feat: add account name to slack messages

### DIFF
--- a/src/LogLambda/index.ts
+++ b/src/LogLambda/index.ts
@@ -104,17 +104,12 @@ function cloudwatchAlarmEventShouldTriggerAlert(message: any): boolean {
  * @returns {object} a message object
  */
 export function slackMessageFromSNSMessage(message: any): any {
+  const account = process.env.ACCOUNT_NAME;
+  if (!account) {
+    throw Error('No account name defined in environment');
+  }
   const eventType = getEventType(message);
-  const formatter = new events[eventType].formatter(message);
-  // if (eventType == 'CloudWatch Alarm State Change') {
-  //   formatter = new AlarmMessageFormatter(message);
-  // } else if (eventType == 'ECS Task State Change') {
-  //   formatter = new EcsMessageFormatter(message);
-  // } else if (eventType == 'EC2 Instance State-change Notification') {
-  //   formatter = new Ec2MessageFormatter(message);
-  // } else {
-  //   throw Error('Unknown event type');
-  // }
+  const formatter = new events[eventType].formatter(message, account);
   return formatter.formattedMessage();
 }
 

--- a/src/LogLambda/template.json
+++ b/src/LogLambda/template.json
@@ -11,12 +11,15 @@
         {
             "type": "context",
             "elements": [
-                {
-                    "type": "plain_text",
-                    "text": "<CONTEXT>",
-                    "emoji": true
-                }
-            ]
+				{
+					"type": "mrkdwn",
+					"text": "Account: *<CONTEXT_ACCOUNT>*"
+				},
+				{
+					"type": "mrkdwn",
+					"text": "Type: *<CONTEXT_TYPE>*"
+				}
+			]
         },
         {
             "type": "section",

--- a/src/LogLambda/test/alarm.test.ts
+++ b/src/LogLambda/test/alarm.test.ts
@@ -7,6 +7,7 @@ import { getEventType, parseMessageFromEvent, messageShouldTriggerAlert, sendMes
 let axiosMock: MockAdapter;
 beforeAll(() => {
   process.env.SLACK_WEBHOOK_URL = 'http://nothing.test';
+  process.env.ACCOUNT_NAME = 'Test-account';
   axiosMock = new MockAdapter(axios);
 });
 

--- a/src/MonitoringLambda.ts
+++ b/src/MonitoringLambda.ts
@@ -6,9 +6,19 @@ import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import { Statics } from './statics';
 
+export interface MonitoringLambdaProps {
+  accountName: string;
+}
+
 export class MonitoringLambda extends Construct {
   function: aws_lambda.Function;
-  constructor(scope: Construct, id: string) {
+
+  /**
+   * Creates a lambda function, this function can receive SNS events
+   * and formats them for processing in Slack. The account name is necessary
+   * to be able to distinguish messages from multiple accounts in the same Slack channel.
+   */
+  constructor(scope: Construct, id: string, props: MonitoringLambdaProps) {
     super(scope, id);
 
     Tags.of(this).add('cdkManaged', 'yes');
@@ -37,6 +47,7 @@ export class MonitoringLambda extends Construct {
         },
       },
       environment: {
+        ACCOUNT_NAME: props.accountName,
         SLACK_WEBHOOK_URL: aws_ssm.StringParameter.valueForStringParameter(this, Statics.ssmSlackWebhookUrl),
       },
     });

--- a/src/MonitoringTargetStage.ts
+++ b/src/MonitoringTargetStage.ts
@@ -1,4 +1,4 @@
-import { aws_kms, aws_sns, aws_ssm, Stack, StackProps, Stage, StageProps, Tags } from 'aws-cdk-lib';
+import { aws_kms, aws_sns, aws_ssm, RemovalPolicy, Stack, StackProps, Stage, StageProps, Tags } from 'aws-cdk-lib';
 import { ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { LambdaSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
 import { NagSuppressions } from 'cdk-nag';
@@ -197,10 +197,11 @@ export class ParameterStack extends Stack {
   constructor(scope: Construct, id: string, props: StackProps) {
     super(scope, id, props);
 
-    new aws_ssm.StringParameter(this, 'ssm_slack_1', {
+    const slackParam = new aws_ssm.StringParameter(this, 'ssm_slack_1', {
       stringValue: '-',
       parameterName: Statics.ssmSlackWebhookUrl,
     });
+    slackParam.applyRemovalPolicy(RemovalPolicy.DESTROY);
   }
 }
 

--- a/src/MonitoringTargetStage.ts
+++ b/src/MonitoringTargetStage.ts
@@ -52,7 +52,7 @@ export class MonitoringTargetStack extends Stack {
 
     this.addEventSubscriptions(topic);
     new DevopsGuruNotifications(this, 'devopsguru', { topic, topicKey: key });
-    this.AddLambdaSubscriber(topic);
+    this.AddLambdaSubscriber(topic, props.accountName);
 
     if (props.assumedRolesToAlarmOn) {
       new AssumedRoleAlarms(this, 'assumed-roles', { cloudTrailLogGroupName: `gemeentenijmegen-${props.accountName}/cloudtrail`, roles: props.assumedRolesToAlarmOn });
@@ -156,8 +156,8 @@ export class MonitoringTargetStack extends Stack {
    *
    * @param topic the SNS topic the lambda should be subscribed to
    */
-  AddLambdaSubscriber(topic: aws_sns.Topic) {
-    const monitoringLambda = new MonitoringLambda(this, 'log-lambda');
+  AddLambdaSubscriber(topic: aws_sns.Topic, accountName: string) {
+    const monitoringLambda = new MonitoringLambda(this, 'log-lambda', { accountName });
     topic.addSubscription(new LambdaSubscription(monitoringLambda.function));
   }
 


### PR DESCRIPTION
Zodat we kunnen zien in welke account iets gebeurd is:

oud:
![Screenshot 2022-08-26 at 11 35 20](https://user-images.githubusercontent.com/992731/186875133-54002066-6153-4725-86d6-af5aac30bd3c.png)

nieuw:
![Screenshot 2022-08-26 at 11 35 32](https://user-images.githubusercontent.com/992731/186875161-9370b9b7-6e3b-4eee-a33d-cdc39ffada7f.png)
 