### PR TITLE
feat: Monitor concurrent executions over all lambdas in region

### DIFF
--- a/src/DefaultAlarms.ts
+++ b/src/DefaultAlarms.ts
@@ -1,0 +1,35 @@
+import { Duration } from 'aws-cdk-lib';
+import { Alarm, Metric } from 'aws-cdk-lib/aws-cloudwatch';
+import { Construct } from 'constructs';
+
+
+export class DefaultAlarms extends Construct {
+  /**
+   * Setup alarms for metrics we want to monitor in each account.
+   */
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    this.addConcurrentExecutionsAlarm();
+  }
+
+  /**
+   * Add an alarm for concurrent executions.
+   *
+   * Alarm is set to alarm at 20 concurrent
+   * executions over all lambdas in the region.
+   */
+  private addConcurrentExecutionsAlarm() {
+    const metric = new Metric({
+      metricName: 'ConcurrentExecutions',
+      namespace: 'AWS/Lambda',
+      statistic: 'Maximum',
+      period: Duration.minutes(5),
+    });
+    new Alarm(this, 'concurrent-executions', {
+      metric: metric,
+      evaluationPeriods: 1,
+      threshold: 20,
+    });
+  }
+}

--- a/src/MonitoringTargetStage.ts
+++ b/src/MonitoringTargetStage.ts
@@ -4,6 +4,7 @@ import { LambdaSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
 import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
 import { AssumedRoleAlarms } from './AssumedRoleAlarms';
+import { DefaultAlarms } from './DefaultAlarms';
 import { DeploymentEnvironment } from './DeploymentEnvironments';
 import { DevopsGuruNotifications } from './DevopsGuruNotifications';
 import { EventSubscription } from './EventSubscription';
@@ -52,6 +53,7 @@ export class MonitoringTargetStack extends Stack {
 
     this.addEventSubscriptions(topic);
     new DevopsGuruNotifications(this, 'devopsguru', { topic, topicKey: key });
+    new DefaultAlarms(this, 'default-alarms');
     this.AddLambdaSubscriber(topic, props.accountName);
 
     if (props.assumedRolesToAlarmOn) {


### PR DESCRIPTION
Ingesteld om te alarmeren op 20. Even gekeken, in de afgelopen maanden is het nooit hoger dan 10 geweest. Dit bekijkt de metric concurrentexecutions over alle lambdas in de account/region.