### PR TITLE
feat: exclude some alarms

### DIFF
--- a/src/DeploymentEnvironments.ts
+++ b/src/DeploymentEnvironments.ts
@@ -4,8 +4,17 @@ export interface DeploymentEnvironment {
   accountName: string;
   env: Environment;
   assumedRolesToAlarmOn?: string|string[];
-  includeMonitoringRules?: string[];
-  excludeMonitoringRules?: string[];
+
+  /**
+   * If set, only event subscriptions matching ids in this array
+   * will be included in the account. No other rules will be added.
+   */
+  includedEventSubscriptions?: string[];
+  /**
+   * if set, event subscriptions matching ids in this array
+   * will be excluded from the default list in the account.
+   */
+  excludedEventSubscriptions?: string[];
 }
 
 /**
@@ -55,7 +64,7 @@ export const deploymentEnvironments: DeploymentEnvironment[] = [
       account: '418648875085',
       region: 'eu-west-1',
     },
-    includeMonitoringRules: [
+    includedEventSubscriptions: [
       'codepipeline-events',
     ],
   },

--- a/src/LogLambda/index.ts
+++ b/src/LogLambda/index.ts
@@ -98,7 +98,7 @@ function cloudwatchAlarmEventShouldTriggerAlert(message: any): boolean {
     'ApplicationInsights/ApplicationInsights-ContainerInsights-ECS_CLUSTER-eform-cluster/ECS/ContainerInsights/NetworkTxBytes/eform-cluster/',
   ];
 
-  if (excludedAlarms.includes(message?.detail?.alarmName)) {
+  if (stringMatchesPatternInArray(excludedAlarms, message?.detail?.alarmName)) {
     return false;
   }
   const state = message?.detail?.state?.value;
@@ -138,3 +138,13 @@ export async function sendMessageToSlack(message: any) {
   return axios.post(process.env.SLACK_WEBHOOK_URL, message);
 }
 
+/**
+ * Check if a string (case insensitive) is includded in an array of strings.
+ * 
+ * @param array an array of lowercased strings
+ * @param string the string to match in the array
+ * @returns 
+ */
+export function stringMatchesPatternInArray(array: string[], string: string) {
+  return array.includes(string.toLowerCase());
+}

--- a/src/LogLambda/index.ts
+++ b/src/LogLambda/index.ts
@@ -146,5 +146,9 @@ export async function sendMessageToSlack(message: any) {
  * @returns 
  */
 export function stringMatchesPatternInArray(array: string[], string: string) {
-  return array.includes(string.toLowerCase());
+  const regExp = new RegExp(string.toLowerCase());
+  const match = array.find((potentialMatch) => {
+    return regExp.test(potentialMatch.toLowerCase());
+  });
+  return match !== undefined;
 }

--- a/src/LogLambda/index.ts
+++ b/src/LogLambda/index.ts
@@ -141,7 +141,7 @@ export async function sendMessageToSlack(message: any) {
 
 /**
  * Check if a string (case insensitive, regex allowed) is included in an array of strings.
- * 
+ *
  * @param array an array of lowercased strings
  * @param string the string to match in the array
  * @returns boolean

--- a/src/LogLambda/index.ts
+++ b/src/LogLambda/index.ts
@@ -96,6 +96,7 @@ function cloudwatchAlarmEventShouldTriggerAlert(message: any): boolean {
     'CIS-Unauthorized Activity Attempt (Custom)',
     'ApplicationInsights/ApplicationInsights-ContainerInsights-ECS_CLUSTER-eform-cluster/ECS/ContainerInsights/NetworkRxBytes/eform-cluster/',
     'ApplicationInsights/ApplicationInsights-ContainerInsights-ECS_CLUSTER-eform-cluster/ECS/ContainerInsights/NetworkTxBytes/eform-cluster/',
+    'ApplicationInsights/ApplicationInsights-ContainerInsights-ECS_CLUSTER-eform-cluster/AWS/ApplicationELB/TargetResponseTime.*',
   ];
 
   if (stringMatchesPatternInArray(excludedAlarms, message?.detail?.alarmName)) {
@@ -139,16 +140,21 @@ export async function sendMessageToSlack(message: any) {
 }
 
 /**
- * Check if a string (case insensitive) is includded in an array of strings.
+ * Check if a string (case insensitive, regex allowed) is included in an array of strings.
  * 
  * @param array an array of lowercased strings
  * @param string the string to match in the array
- * @returns 
+ * @returns boolean
  */
-export function stringMatchesPatternInArray(array: string[], string: string) {
-  const regExp = new RegExp(string.toLowerCase());
+export function stringMatchesPatternInArray(array: string[], string: string): boolean {
+  const lowerCasedString = string.toLowerCase();
   const match = array.find((potentialMatch) => {
-    return regExp.test(potentialMatch.toLowerCase());
+    const regExp = new RegExp(potentialMatch.toLowerCase());
+    return regExp.test(escapeRegExp(lowerCasedString));
   });
   return match !== undefined;
+}
+
+function escapeRegExp(string: string): string {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 }

--- a/src/LogLambda/test/utils.test.ts
+++ b/src/LogLambda/test/utils.test.ts
@@ -20,4 +20,13 @@ describe('Test patterns', () => {
     expect(stringMatchesPatternInArray(pattern, string)).toBe(true);
   });
 
+
+  test('regex strings', () => {
+    const string = 'This should match .*';
+    const pattern = [
+      'this should match the full string'
+    ];
+    expect(stringMatchesPatternInArray(pattern, string)).toBe(true);
+  });
+
 });

--- a/src/LogLambda/test/utils.test.ts
+++ b/src/LogLambda/test/utils.test.ts
@@ -22,9 +22,17 @@ describe('Test patterns', () => {
 
 
   test('regex strings', () => {
-    const string = 'This should match .*';
+    const string = 'This should match the full string';
     const pattern = [
-      'this should match the full string'
+      'This should match .*'
+    ];
+    expect(stringMatchesPatternInArray(pattern, string)).toBe(true);
+  });
+
+  test('strings with special chars', () => {
+    const string = 'ApplicationInsights/ApplicationInsights-ContainerInsights-ECS_CLUSTER-eform-cluster/AWS/ApplicationELB/TargetResponseTime/app/Produ-loadb-1X';
+    const pattern = [
+      'ApplicationInsights/ApplicationInsights-ContainerInsights-ECS_CLUSTER-eform-cluster/AWS/ApplicationELB/TargetResponseTime.*'
     ];
     expect(stringMatchesPatternInArray(pattern, string)).toBe(true);
   });

--- a/src/LogLambda/test/utils.test.ts
+++ b/src/LogLambda/test/utils.test.ts
@@ -7,7 +7,7 @@ describe('Test patterns', () => {
   test('full strings', () => {
     const string = 'This should match the full string';
     const pattern = [
-      'This should match the full string'
+      'This should match the full string',
     ];
     expect(stringMatchesPatternInArray(pattern, string)).toBe(true);
   });
@@ -15,7 +15,7 @@ describe('Test patterns', () => {
   test('case insensitive strings', () => {
     const string = 'This should match the full string';
     const pattern = [
-      'this should match the full string'
+      'this should match the full string',
     ];
     expect(stringMatchesPatternInArray(pattern, string)).toBe(true);
   });
@@ -24,7 +24,7 @@ describe('Test patterns', () => {
   test('regex strings', () => {
     const string = 'This should match the full string';
     const pattern = [
-      'This should match .*'
+      'This should match .*',
     ];
     expect(stringMatchesPatternInArray(pattern, string)).toBe(true);
   });
@@ -32,7 +32,7 @@ describe('Test patterns', () => {
   test('strings with special chars', () => {
     const string = 'ApplicationInsights/ApplicationInsights-ContainerInsights-ECS_CLUSTER-eform-cluster/AWS/ApplicationELB/TargetResponseTime/app/Produ-loadb-1X';
     const pattern = [
-      'ApplicationInsights/ApplicationInsights-ContainerInsights-ECS_CLUSTER-eform-cluster/AWS/ApplicationELB/TargetResponseTime.*'
+      'ApplicationInsights/ApplicationInsights-ContainerInsights-ECS_CLUSTER-eform-cluster/AWS/ApplicationELB/TargetResponseTime.*',
     ];
     expect(stringMatchesPatternInArray(pattern, string)).toBe(true);
   });

--- a/src/LogLambda/test/utils.test.ts
+++ b/src/LogLambda/test/utils.test.ts
@@ -1,0 +1,23 @@
+import { stringMatchesPatternInArray } from '../index';
+
+beforeAll(() => {
+});
+
+describe('Test patterns', () => {
+  test('full strings', () => {
+    const string = 'This should match the full string';
+    const pattern = [
+      'This should match the full string'
+    ];
+    expect(stringMatchesPatternInArray(pattern, string)).toBe(true);
+  });
+
+  test('case insensitive strings', () => {
+    const string = 'This should match the full string';
+    const pattern = [
+      'this should match the full string'
+    ];
+    expect(stringMatchesPatternInArray(pattern, string)).toBe(true);
+  });
+
+});

--- a/src/MonitoringTargetStage.ts
+++ b/src/MonitoringTargetStage.ts
@@ -120,13 +120,14 @@ export class MonitoringTargetStack extends Stack {
     ];
 
     const includeFilter = (sub: { id: string }) => {
-      return props.includeMonitoringRules ? props.includeMonitoringRules.includes(sub.id) : true;
+      return props.includedEventSubscriptions ? props.includedEventSubscriptions.includes(sub.id) : true;
     };
     const excludeFilter = (sub: { id: string }) => {
-      return props.excludeMonitoringRules ? !props.excludeMonitoringRules.includes(sub.id) : true;
+      return props.excludedEventSubscriptions ? !props.excludedEventSubscriptions.includes(sub.id) : true;
     };
 
-    eventSubscriptions.filter(includeFilter)
+    eventSubscriptions
+      .filter(includeFilter)
       .filter(excludeFilter)
       .forEach(subscription =>
         new EventSubscription(this, subscription.id, {


### PR DESCRIPTION
Fixes [#46](https://github.com/GemeenteNijmegen/aws-monitoring/issues/46)

- de event subscription filters hernoemd en gedocumenteerd (@marnixdessing klopt wat ik zeg hierin?)
- de alarm-filterlijst bijgewerkt, + regex-checks mogelijk gemaakt.