### PR TITLE
feat: Format cloudtrail error logs (#76)

### DIFF
--- a/src/LogLambda/LogsEventHandler.ts
+++ b/src/LogLambda/LogsEventHandler.ts
@@ -39,7 +39,7 @@ export class LogsEventHandler implements IHandler {
       'errorMessage',
       'userIdentity',
       'eventSource',
-      'eventName'
+      'eventName',
     ];
     return parsed.logEvents.find((logEvent) => {
       try {

--- a/src/LogLambda/test/logs-handler.test.ts
+++ b/src/LogLambda/test/logs-handler.test.ts
@@ -1,7 +1,7 @@
 
 import { LogsEventHandler } from '../LogsEventHandler';
 import { SnsEventHandler } from '../SnsEventHandler';
-import { constructLogSubscriptionEvent } from './util';
+import { constructLogSubscriptionEvent, getEventFromFilePath } from './util';
 
 beforeAll(() => {
   process.env.ACCOUNT_NAME = 'testing';
@@ -62,4 +62,26 @@ describe('Log subscription events', () => {
     expect(message.blocks[5].text.text).toContain(JSON.stringify(log4));
   });
 
+  test('Log event with cloudtrail errors', async () => {
+    const logMessage = await getEventFromFilePath('samples/log-event.json');
+    const event = constructLogSubscriptionEvent({}, logMessage);
+    const handled = logsHandler.handle(event);
+    expect(handled).not.toBeFalsy();
+    if (handled == false) { return; }
+
+    const message = handled.message.getSlackMessage();
+    console.debug(JSON.stringify(message));
+    expect(message.blocks[0].text.text).toBe('AccessDenied');
+  });
+
+  test('Log event with cloudtrail and other errors', async () => {
+    const logMessage = await getEventFromFilePath('samples/log-event.json');
+    const event = constructLogSubscriptionEvent({}, logMessage, { errorCode: 'bla', errorMessage: 'something', userIdentity: { principalId: 'me' } });
+    const handled = logsHandler.handle(event);
+    expect(handled).not.toBeFalsy();
+    if (handled == false) { return; }
+
+    const message = handled.message.getSlackMessage();
+    expect(message.blocks[0].text.text).toBe('Error');
+  });
 });

--- a/src/LogLambda/test/samples/log-event.json
+++ b/src/LogLambda/test/samples/log-event.json
@@ -1,0 +1,42 @@
+{
+  "eventVersion": "1.08",
+  "userIdentity": {
+    "type": "AssumedRole",
+    "principalId": "<test>:securityhub",
+    "arn": "arn:aws:sts::acctid:assumed-role/AWSServiceRoleForSecurityHub/securityhub",
+    "accountId": "acctid",
+    "accessKeyId": "ASIAS3LZURMZZPRP65E5",
+    "sessionContext": {
+      "sessionIssuer": {
+        "type": "Role",
+        "principalId": "<test>",
+        "arn": "arn:aws:iam::acctid:role/aws-service-role/securityhub.amazonaws.com/AWSServiceRoleForSecurityHub",
+        "accountId": "acctid",
+        "userName": "AWSServiceRoleForSecurityHub"
+      },
+      "webIdFederationData": {},
+      "attributes": {
+        "creationDate": "2023-01-12T15:26:11Z",
+        "mfaAuthenticated": "false"
+      }
+    },
+    "invokedBy": "securityhub.amazonaws.com"
+  },
+  "eventTime": "2023-01-12T15:26:11Z",
+  "eventSource": "sns.amazonaws.com",
+  "eventName": "ListSubscriptionsByTopic",
+  "awsRegion": "eu-west-1",
+  "sourceIPAddress": "securityhub.amazonaws.com",
+  "userAgent": "securityhub.amazonaws.com",
+  "errorCode": "AccessDenied",
+  "errorMessage": "User: arn:aws:sts::acctid:assumed-role/AWSServiceRoleForSecurityHub/securityhub is not authorized to perform: SNS:ListSubscriptionsByTopic on resource: arn:aws:sns:eu-west-1:382378071824:CWAlarmDummyTopic because no resource-based policy allows the SNS:ListSubscriptionsByTopic action",
+  "requestParameters": null,
+  "responseElements": null,
+  "requestID": "69f6cdfe-7b03-55b1-976c-91c453d0f510",
+  "eventID": "941bcadb-9e14-490a-a35c-e729da53c60c",
+  "readOnly": true,
+  "eventType": "AwsApiCall",
+  "managementEvent": true,
+  "recipientAccountId": "acctid",
+  "eventCategory": "Management"
+}


### PR DESCRIPTION
Adds logic to the logs-handler to detect (cloudtrail) error logs, and adds a message formatter that extracts the error code and message for these logs, only sending those in the message. The header is based on the error code, but only if all messages in the event are of the same type.

Co-authored-by: Marnix Dessing <marnixdessing@hotmail.com>
Co-authored-by: Martijn van Dijk <m.van.dijk@nijmegen.nl>

Fixes #