### PR TITLE
feat: Allow exclusion of string patterns from Logs

### DIFF
--- a/src/LogLambda/LogsEventHandler.ts
+++ b/src/LogLambda/LogsEventHandler.ts
@@ -2,7 +2,12 @@ import * as zlib from 'zlib';
 import { CloudWatchLogsDecodedData, CloudWatchLogsEvent } from 'aws-lambda';
 import { HandledEvent, IHandler } from './IHandler';
 import { LogsMessageFormatter, CloudTrailErrorLogsMessageFormatter } from './MessageFormatter';
-import { getAccount } from './utils';
+import { getAccount, stringMatchesPatternInArray } from './utils';
+
+
+const excludedMessageStrings = [
+  'assumed-role/config-drift-detection-role/configLambdaExecution is not authorized to perform: iam:GetRole on resource',
+];
 
 
 export class LogsEventHandler implements IHandler {
@@ -14,6 +19,12 @@ export class LogsEventHandler implements IHandler {
   handle(event: any): HandledEvent | false {
     try {
       const parsed = parseMessageFromEvent(event);
+      
+      // Remove excluded log events
+      parsed.logEvents = parsed.logEvents.filter((event) => !stringMatchesPatternInArray(excludedMessageStrings, event.message));
+      // If all messages are excluded, stop handling.
+      if(parsed.logEvents.length == 0) { return false; }
+      
       let formatter = this.selectMessageFormatter(parsed);
       return {
         priority: 'high',
@@ -52,6 +63,7 @@ export class LogsEventHandler implements IHandler {
       }
     });
   }
+
 }
 
 function parseMessageFromEvent(event: CloudWatchLogsEvent): CloudWatchLogsDecodedData {

--- a/src/LogLambda/SnsEventHandler.ts
+++ b/src/LogLambda/SnsEventHandler.ts
@@ -1,6 +1,6 @@
 import { HandledEvent, IHandler, Priority } from './IHandler';
 import { UnhandledEventFormatter, AlarmMessageFormatter, EcsMessageFormatter, Ec2MessageFormatter, DevopsGuruMessageFormatter, CertificateExpiryFormatter, CodePipelineFormatter, HealthDashboardFormatter, InspectorFindingFormatter, MessageFormatter, DriftDetectionStatusFormatter } from './MessageFormatter';
-import { getAccount } from './utils';
+import { getAccount, stringMatchesPatternInArray } from './utils';
 
 /**
  * This maps the type of notifications this lambda can handle. Not all notifications should trigger
@@ -139,7 +139,6 @@ export function messageShouldTriggerAlert(message: any): boolean {
  * OK or vice versa is not a relevant alert. New or ended alarms should report.
  *
  * @param message an SNS message containing a cloudwatch state changed event
- * @param excludedAlarms the list of allarms to exclude
  */
 function cloudwatchAlarmEventShouldTriggerAlert(message: any): boolean {
 
@@ -152,24 +151,4 @@ function cloudwatchAlarmEventShouldTriggerAlert(message: any): boolean {
     return true;
   }
   return false;
-}
-
-/**
- * Check if a string (case insensitive, regex allowed) is included in an array of strings.
- *
- * @param array an array of lowercased strings
- * @param string the string to match in the array
- * @returns boolean
- */
-export function stringMatchesPatternInArray(array: string[], string: string): boolean {
-  const lowerCasedString = string.toLowerCase();
-  const match = array.find((potentialMatch) => {
-    const regExp = new RegExp(potentialMatch.toLowerCase());
-    return regExp.test(escapeRegExp(lowerCasedString));
-  });
-  return match !== undefined;
-}
-
-function escapeRegExp(string: string): string {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 }

--- a/src/LogLambda/test/logs-handler.test.ts
+++ b/src/LogLambda/test/logs-handler.test.ts
@@ -23,14 +23,14 @@ describe('Log subscription events', () => {
   const logStr1 = 'log-string-1';
   const logStr2 = 'log-string-2';
 
-  test('Test log event with strings', async () => {
+  test('Log event with strings creates message', async () => {
     const event = constructLogSubscriptionEvent({}, logStr1, logStr2);
 
     const handled = logsHandler.handle(event);
     expect(logsHandler.canHandle(event)).toBeTruthy();
     expect(snsHandler.canHandle(event)).toBeFalsy();
     expect(handled).not.toBeFalsy(); // Returns false if skipped
-    if (handled == false) { return; }
+    if (handled == false) { throw Error('this should not be false'); }
     expect(handled.priority).toBe('high');
 
     const message = handled.message.getSlackMessage();
@@ -42,14 +42,14 @@ describe('Log subscription events', () => {
 
   });
 
-  test('Test log event with stringified objects', async () => {
+  test('Test log event with stringified objects creates messages', async () => {
     const event = constructLogSubscriptionEvent({}, log1, log2, log3, log4);
 
     const handled = logsHandler.handle(event);
     expect(logsHandler.canHandle(event)).toBeTruthy();
     expect(snsHandler.canHandle(event)).toBeFalsy();
     expect(handled).not.toBeFalsy();
-    if (handled == false) { return; }
+    if (handled == false) { throw Error('this should not be false'); }
     expect(handled.priority).toBe('high');
 
     const message = handled.message.getSlackMessage();
@@ -62,26 +62,40 @@ describe('Log subscription events', () => {
     expect(message.blocks[5].text.text).toContain(JSON.stringify(log4));
   });
 
-  test('Log event with cloudtrail errors', async () => {
+  test('Log event with cloudtrail errors is formatted', async () => {
     const logMessage = await getEventFromFilePath('samples/log-event.json');
     const event = constructLogSubscriptionEvent({}, logMessage);
     const handled = logsHandler.handle(event);
     expect(handled).not.toBeFalsy();
-    if (handled == false) { return; }
+    if (handled == false) { throw Error('should not be false'); }
 
     const message = handled.message.getSlackMessage();
-    console.debug(JSON.stringify(message));
     expect(message.blocks[0].text.text).toBe('AccessDenied');
   });
 
-  test('Log event with cloudtrail and other errors', async () => {
+  test('Log event with cloudtrail and other errors is formatted', async () => {
     const logMessage = await getEventFromFilePath('samples/log-event.json');
     const event = constructLogSubscriptionEvent({}, logMessage, { errorCode: 'bla', errorMessage: 'something', userIdentity: { principalId: 'me' } });
     const handled = logsHandler.handle(event);
     expect(handled).not.toBeFalsy();
-    if (handled == false) { return; }
+    if (handled == false) { throw Error('this should not be false'); }
 
     const message = handled.message.getSlackMessage();
     expect(message.blocks[0].text.text).toBe('Error');
+  });
+
+  test('Log event with excluded strings returns false', async () => {
+    const event = constructLogSubscriptionEvent({}, 'User: arn:aws:sts::123456:assumed-role/config-drift-detection-role/configLambdaExecution is not authorized to perform: iam:GetRole on resource: role cdk-hnb659fds-lookup-role-123456-eu-west-1 because no identity-based policy allows the iam:GetRole action');
+    const handled = logsHandler.handle(event);
+    expect(handled).toBeFalsy();
+  });
+
+  test('Log event with excluded and not excluded strings filters excluded strings', async () => {
+    const event = constructLogSubscriptionEvent({}, 'User: arn:aws:sts::123456:assumed-role/config-drift-detection-role/configLambdaExecution is not authorized to perform: iam:GetRole on resource: role cdk-hnb659fds-lookup-role-123456-eu-west-1 because no identity-based policy allows the iam:GetRole action', 'another log message');
+    const handled = logsHandler.handle(event);
+    if (handled == false) { throw Error('this should not be false'); }
+    expect(handled).not.toBeFalsy();
+    const message = handled.message.getSlackMessage();
+    expect(message.blocks.filter((block: any) => block.type == 'section').length).toBe(1);
   });
 });

--- a/src/LogLambda/test/utils.test.ts
+++ b/src/LogLambda/test/utils.test.ts
@@ -1,6 +1,5 @@
 import { SlackMessage } from '../SlackMessage';
-import { stringMatchesPatternInArray } from '../SnsEventHandler';
-import { getAccount } from '../utils';
+import { getAccount, stringMatchesPatternInArray} from '../utils';
 
 beforeAll(() => {
   process.env.ACCOUNT_NAME = 'test-account-name';
@@ -39,7 +38,6 @@ describe('Test patterns', () => {
     ];
     expect(stringMatchesPatternInArray(pattern, string)).toBe(true);
   });
-
 });
 
 

--- a/src/LogLambda/utils.ts
+++ b/src/LogLambda/utils.ts
@@ -10,3 +10,23 @@ export function getAccount(): string {
   }
   return account;
 }
+
+/**
+ * Check if a string (case insensitive, regex allowed) is included in an array of strings.
+ *
+ * @param array an array of lowercased strings
+ * @param string the string to match in the array
+ * @returns boolean
+ */
+
+export function stringMatchesPatternInArray(array: string[], string: string): boolean {
+  const lowerCasedString = string.toLowerCase();
+  const match = array.find((potentialMatch) => {
+    const regExp = new RegExp(potentialMatch.toLowerCase());
+    return regExp.test(escapeRegExp(lowerCasedString));
+  });
+  return match !== undefined;
+}
+function escapeRegExp(string: string): string {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}


### PR DESCRIPTION
Allows specifying regex patterns to exclude from (cloudtrail) logs.
Matched exclusion strings are filtered from the log events returned to
the messageFormatter. If all events in a log message are excluded, the
handler will return false, and no message will be sent.

This adds a match for drift detection, which is currently not setup
entirely correctly.