### PR TITLE
feat: use branch dependent configuration for accountname lookup

### DIFF
--- a/src/DeploymentEnvironments.ts
+++ b/src/DeploymentEnvironments.ts
@@ -47,7 +47,6 @@ export interface Configuration {
 /**
  * List all environments for which which a monitoring
  * pipeline should be deployed in prod
- * Note: separate monitoring resources are deployed to the MPA account
  */
 export const deploymentEnvironments: { [key: string]: Configuration } = {
   'main-new-lz': {

--- a/src/DeploymentEnvironments.ts
+++ b/src/DeploymentEnvironments.ts
@@ -22,77 +22,123 @@ export interface DeploymentEnvironment {
   enableDevopsGuru?: boolean;
 }
 
+export interface Configuration {
+  /**
+   * The branch name to build
+   */
+  branchName: string;
+
+  /**
+   * The name of the environment to deploy to
+   */
+  environmentName: 'development' | 'production';
+
+  /**
+   * The list of environments to deploy to
+   */
+  deployToEnvironments: DeploymentEnvironment[];
+
+  /**
+   * The CDK id for the pipeline stack (in main.ts)
+   */
+  pipelineStackCdkName: string;
+}
+
 /**
  * List all environments for which which a monitoring
  * pipeline should be deployed in prod
  * Note: separate monitoring resources are deployed to the MPA account
  */
-export const deploymentEnvironments: DeploymentEnvironment[] = [
-  {
-    accountName: 'gn-build',
-    env: {
-      account: Statics.gnBuildAccount,
-      region: 'eu-central-1',
-    },
-    enableDevopsGuru: true,
+export const deploymentEnvironments: { [key: string]: Configuration } = {
+  'main-new-lz': {
+    branchName: 'main-new-lz',
+    environmentName: 'production',
+    pipelineStackCdkName: 'aws-monitoring-prod',
+    deployToEnvironments: [
+      {
+        accountName: 'gn-build',
+        env: {
+          account: Statics.gnBuildAccount,
+          region: 'eu-central-1',
+        },
+        enableDevopsGuru: true,
+      },
+      {
+        accountName: 'gn-geo-data-production',
+        env: {
+          account: '549334216741',
+          region: 'eu-central-1',
+        },
+      },
+      {
+        accountName: 'gn-geo-data-acceptance',
+        env: {
+          account: '766983128454',
+          region: 'eu-central-1',
+        },
+      },
+      {
+        accountName: 'gn-yivi-accp',
+        env: {
+          account: '699363516011',
+          region: 'eu-central-1',
+        },
+      },
+      {
+        accountName: 'gn-yivi-prod',
+        enableDevopsGuru: true,
+        env: {
+          account: '185512167111',
+          region: 'eu-central-1',
+        },
+      },
+      {
+        accountName: 'gn-yivi-brp-issue-accp',
+        env: {
+          account: '528030426040',
+          region: 'eu-central-1',
+        },
+      },
+      {
+        accountName: 'gn-yivi-brp-issue-prod',
+        enableDevopsGuru: true,
+        env: {
+          account: '079163754011',
+          region: 'eu-central-1',
+        },
+      },
+      {
+        accountName: 'gn-mijn-nijmegen-accp',
+        env: {
+          account: '021929636313',
+          region: 'eu-central-1',
+        },
+      },
+      {
+        accountName: 'gn-mijn-nijmegen-prod',
+        enableDevopsGuru: true,
+        env: {
+          account: '740606269759',
+          region: 'eu-central-1',
+        },
+      },
+    ],
   },
-  {
-    accountName: 'gn-geo-data-production',
-    env: {
-      account: '549334216741',
-      region: 'eu-central-1',
-    },
+  'sandbox-new-lz': {
+    branchName: 'sandbox-new-lz',
+    environmentName: 'development',
+    pipelineStackCdkName: 'aws-monitoring-sandbox',
+    deployToEnvironments: [
+      { accountName: 'workload-test', env: Statics.sandboxEnvironment, enableDevopsGuru: true },
+    ],
   },
-  {
-    accountName: 'gn-geo-data-acceptance',
-    env: {
-      account: '766983128454',
-      region: 'eu-central-1',
-    },
-  },
-  {
-    accountName: 'gn-yivi-accp',
-    env: {
-      account: '699363516011',
-      region: 'eu-central-1',
-    },
-  },
-  {
-    accountName: 'gn-yivi-prod',
-    enableDevopsGuru: true,
-    env: {
-      account: '185512167111',
-      region: 'eu-central-1',
-    },
-  },
-  {
-    accountName: 'gn-yivi-brp-issue-accp',
-    env: {
-      account: '528030426040',
-      region: 'eu-central-1',
-    },
-  },
-  {
-    accountName: 'gn-yivi-brp-issue-prod',
-    enableDevopsGuru: true,
-    env: {
-      account: '079163754011',
-      region: 'eu-central-1',
-    },
-  },
-  {
-    accountName: 'gn-mijn-nijmegen-accp',
-    env: {
-      account: '021929636313',
-      region: 'eu-central-1',
-    },
-  },
-  {
-    accountName: 'gn-mijn-nijmegen-prod',
-    enableDevopsGuru: true,
-    env: {
-      account: '740606269759',
-      region: 'eu-central-1',
-    },
-  },
-];
+};
+
+
+export function getConfiguration(branchName: string): Configuration {
+  const config = deploymentEnvironments[branchName];
+  if (!config) {
+    throw new Error(`No configuration found for branch ${branchName}`);
+  }
+  return config;
+}

--- a/src/MonitoringTargetStage.ts
+++ b/src/MonitoringTargetStage.ts
@@ -12,6 +12,7 @@ import { Statics } from './statics';
 export interface MonitoringTargetStageProps extends StageProps {
   deployToEnvironments: DeploymentEnvironment[];
   isProduction?: boolean;
+  branchName: string;
 }
 
 export interface EventSubscriptionConfiguration {
@@ -49,6 +50,7 @@ export class MonitoringTargetStage extends Stage {
     new AggregatorStack(this, 'aggregator', {
       env: Statics.aggregatorEnvironment,
       prefix: parameterPrefix,
+      branchName: props.branchName,
     }).addDependency(parameterStack);
 
     new IntegrationsStack(this, 'integrations', {

--- a/src/PipelineStack.ts
+++ b/src/PipelineStack.ts
@@ -32,6 +32,7 @@ export class PipelineStack extends Stack {
       {
         deployToEnvironments: props.deployToEnvironments,
         isProduction: props.isProduction,
+        branchName: props.branchName,
       }));
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,40 +1,25 @@
 import { App } from 'aws-cdk-lib';
-import { deploymentEnvironments } from './DeploymentEnvironments';
+import { getConfiguration } from './DeploymentEnvironments';
 import { PipelineStack } from './PipelineStack';
 import { Statics } from './statics';
 
-// for development, use sandbox account
 const deployFromEnvironment = {
   account: Statics.gnBuildAccount,
   region: 'eu-central-1',
 };
 
-const sandboxEnvironment = {
-  account: Statics.gnTestAccount,
-  region: 'eu-central-1',
-};
-
 const app = new App();
 
-if ('BRANCH_NAME' in process.env == false || process.env.BRANCH_NAME == 'sandbox-new-lz') {
-  new PipelineStack(app, 'aws-monitoring-sandbox',
-    {
-      env: deployFromEnvironment,
-      branchName: 'sandbox-new-lz',
-      deployToEnvironments: [{ accountName: 'workload-test', env: sandboxEnvironment, enableDevopsGuru: true }],
-      environmentName: 'development',
-    },
-  );
-} else if ( process.env.BRANCH_NAME == 'main-new-lz') {
-  new PipelineStack(app, 'aws-monitoring-prod',
-    {
-      env: deployFromEnvironment,
-      branchName: 'main-new-lz',
-      deployToEnvironments: deploymentEnvironments,
-      environmentName: 'production',
-      isProduction: true,
-    },
-  );
-}
+const branchToBuild = process.env.BRANCH_NAME ?? 'sandbox-new-lz';
+console.log(`Branch to build: ${branchToBuild}`);
+const configuration = getConfiguration(branchToBuild);
+
+new PipelineStack(app, configuration.pipelineStackCdkName, {
+  env: deployFromEnvironment,
+  branchName: configuration.branchName,
+  deployToEnvironments: configuration.deployToEnvironments,
+  environmentName: configuration.environmentName,
+  isProduction: configuration.environmentName == 'production',
+});
 
 app.synth();

--- a/src/monitoringLambda/MessageFormatter.ts
+++ b/src/monitoringLambda/MessageFormatter.ts
@@ -2,7 +2,7 @@ import { CloudWatchLogsDecodedData } from 'aws-lambda';
 import { Message } from './Message';
 import { SlackMessage } from './SlackMessage';
 import { getEventType } from './SnsEventHandler';
-import { deploymentEnvironments } from '../DeploymentEnvironments';
+import { getConfiguration } from '../DeploymentEnvironments';
 
 /**
  * Abstract class for formatting differnt types of events
@@ -43,8 +43,9 @@ export abstract class MessageFormatter<T> {
    * @returns
    */
   lookupAccountName(account: string) {
-    const config = deploymentEnvironments.find(deploymentEnv => deploymentEnv.env.account == account);
-    return config?.accountName ?? account;
+    const config = getConfiguration(process.env.BRANCH_NAME ?? 'main-new-lz');
+    const monitoringConfig = config.deployToEnvironments.find(deploymentEnv => deploymentEnv.env.account == account);
+    return monitoringConfig?.accountName ?? account;
   }
 
 }

--- a/src/statics.ts
+++ b/src/statics.ts
@@ -16,30 +16,15 @@ export abstract class Statics {
   static readonly gnBuildAccount: string = '836443378780';
   static readonly gnAggregatorAccount: string = '302838002127';
   static readonly gnTestAccount: string = '095798249317';
-  static readonly gnMpa: string = '427617903428';
 
   static readonly aggregatorEnvironment = {
     account: Statics.gnAggregatorAccount,
     region: 'eu-central-1',
   };
 
-  static readonly mpaEnvironment = {
-    account: Statics.gnMpa,
-    region: 'eu-central-1',
-  };
-
   static readonly sandboxEnvironment = {
     account: Statics.gnTestAccount,
     region: 'eu-central-1',
-  };
-
-  /**
-   * MPA orgtrail
-   */
-  static readonly orgTrailLogGroupName = 'aws-controltower/CloudTrailLogs';
-  static readonly assumedRolesToAlarmOn: {[key: string]: Priority} = {
-    'lz-platform-operator-ep': 'high',
-    'landingzone-break-glass': 'critical',
   };
 
   /**

--- a/src/statics.ts
+++ b/src/statics.ts
@@ -28,6 +28,10 @@ export abstract class Statics {
     region: 'eu-central-1',
   };
 
+  static readonly sandboxEnvironment = {
+    account: Statics.gnTestAccount,
+    region: 'eu-central-1',
+  };
 
   /**
    * MPA orgtrail


### PR DESCRIPTION
- Add configuration object
- Get configuration object based on branch name
- Lookup account name (monitoring lambda) now gets the correct configuration object (see below)

Due to the previously implemented lookup function for the account name in the MessageFormatter class the configuration object without branch specification was used (e.g. sandbox branch used the main configuration for lookups). This PR will make configuration branch dependent such that the lambda can use the corresponding configuration object for lookup.