### PR TITLE
feat: Move log query access LogQueryAccessRole

### DIFF
--- a/src/AggregatorStack.ts
+++ b/src/AggregatorStack.ts
@@ -106,11 +106,11 @@ class Notifier extends Construct {
     this.subscribeLambda(lambda);
   }
 
-  setupLogQueryJob(prefix: string, brancName: string) {
+  setupLogQueryJob(prefix: string, branchName: string) {
     new LogQueryJob(this, 'log-query-job', {
       prefix: prefix,
-      branchName: brancName,
-      deployToEnvironments: getConfiguration(brancName).deployToEnvironments,
+      branchName: branchName,
+      deployToEnvironments: getConfiguration(branchName).deployToEnvironments,
     });
   }
 

--- a/src/DeploymentEnvironments.ts
+++ b/src/DeploymentEnvironments.ts
@@ -29,7 +29,7 @@ export interface DeploymentEnvironment {
    * To incldue a query here gant that role permissions to the corresponding log groups.
    * @default none
    */
-  queryDefinitons?: CloudWatchInsightsQueryProps[];
+  queryDefinitions?: CloudWatchInsightsQueryProps[];
 }
 
 export interface Configuration {
@@ -92,7 +92,7 @@ export const deploymentEnvironments: { [key: string]: Configuration } = {
           account: '699363516011',
           region: 'eu-central-1',
         },
-        queryDefinitons: [
+        queryDefinitions: [
           {
             name: 'errors-in-yivi-issue-app',
             description: 'Errors in yivi-issue-app',
@@ -159,7 +159,7 @@ export const deploymentEnvironments: { [key: string]: Configuration } = {
         accountName: 'workload-test',
         env: Statics.sandboxEnvironment,
         enableDevopsGuru: true,
-        queryDefinitons: [
+        queryDefinitions: [
           {
             name: 'random-log-group-query',
             description: 'Some random testing query',

--- a/src/LogQueryAccessRole.ts
+++ b/src/LogQueryAccessRole.ts
@@ -1,0 +1,71 @@
+import { Stack, aws_iam as iam } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { CloudWatchInsightsQueryProps } from './LogQueryJob/Query';
+import { Statics } from './statics';
+
+interface LogQueryAccessRoleProps {
+  queryDefinitions: CloudWatchInsightsQueryProps[];
+}
+/**
+ * Define a new role to be assumed from the log query lambda function.
+ *
+ * The role allows access to cloudwatch logs (queries start, stop and get results),
+ * and the log groups defined in the querydefinitions.
+ * @param props
+ */
+export class LogQueryAccessRole extends Construct {
+  constructor(scope: Construct, id: string, props: LogQueryAccessRoleProps) {
+    super(scope, id);
+    this.setupLogQueryJobAccess(props.queryDefinitions);
+  }
+
+  private setupLogQueryJobAccess(queryDefinitions: CloudWatchInsightsQueryProps[]) {
+    const logGroupArns: string[] = this.logGroupArnsFromDefinition(queryDefinitions);
+
+    const role = new iam.Role(this, 'log-query-job-access-role', {
+      roleName: Statics.logQueryJobAccessRoleName,
+      assumedBy: new iam.ArnPrincipal(`arn:aws:iam::${Statics.gnAuditAccount}:role/log-query-job-lambda-role-dev`),
+      description: 'Role to assume from the log query lambda function',
+    });
+
+    // Allow both the dev and prod lambas to assume this role
+    role.grantAssumeRole(new iam.ArnPrincipal(`arn:aws:iam::${Statics.gnAuditAccount}:role/log-query-job-lambda-role-prod`));
+
+    // Allow the role to use CloudWatch queries
+    role.addToPolicy(new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: [
+        'logs:GetQueryResults',
+        'logs:StartQuery',
+        'logs:StopQuery',
+      ],
+      resources: ['*'],
+    }));
+
+    // Provide the role access to the log groups that are queried
+    role.addToPolicy(new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: [
+        'logs:DescribeLogGroups',
+        'logs:GetLogGroupFields',
+        'logs:GetLogEvents',
+      ],
+      resources: logGroupArns,
+    }));
+
+  }
+
+  private logGroupArnsFromDefinition(queryDefinitions: CloudWatchInsightsQueryProps[]) {
+    const account = Stack.of(this).account;
+    const region = Stack.of(this).region;
+    const logGroupArns: string[] = [];
+
+    queryDefinitions.forEach(queryDefinition => {
+      queryDefinition.logGroupNames.forEach(logGroupName => {
+        logGroupArns.push(`arn:aws:logs:${region}:${account}:log-group:${logGroupName}`);
+        logGroupArns.push(`arn:aws:logs:${region}:${account}:log-group:${logGroupName}:*`);
+      });
+    });
+    return logGroupArns;
+  }
+}

--- a/src/LogQueryJob.ts
+++ b/src/LogQueryJob.ts
@@ -85,7 +85,7 @@ export class LogQueryJob extends Construct {
 
     const accountsToQuery: string[] = [];
     deploymentEnvironments.forEach((env) => {
-      if (env.queryDefinitons && env.env.account) {
+      if (env.queryDefinitions && env.env.account) {
         console.log(`Adding permission to assume the query logs role in ${env.env.account}`);
         accountsToQuery.push(env.env.account);
       }

--- a/src/LogQueryJob/LogQueryJob.lambda.ts
+++ b/src/LogQueryJob/LogQueryJob.lambda.ts
@@ -50,10 +50,10 @@ async function runLogQueryJob(deploymentConfiguration: DeploymentEnvironment[]) 
   const queries: Promise<string>[] = [];
 
   deploymentConfiguration.forEach(configuration => {
-    if (!configuration.queryDefinitons) {
+    if (!configuration.queryDefinitions) {
       return;
     }
-    configuration.queryDefinitons.forEach(queryDefiniton => {
+    configuration.queryDefinitions.forEach(queryDefiniton => {
       queries.push(executeQuery(configuration.env, queryDefiniton, timestamp));
     });
   });

--- a/src/MonitoredAccountStack.ts
+++ b/src/MonitoredAccountStack.ts
@@ -4,9 +4,9 @@ import { DefaultAlarms } from './DefaultAlarms';
 import { DeploymentEnvironment } from './DeploymentEnvironments';
 import { DevopsGuruMonitoring } from './DevopsGuruMonitoring';
 import { EventSubscription } from './EventSubscription';
+import { LogQueryAccessRole } from './LogQueryAccessRole';
 import { EventSubscriptionConfiguration } from './MonitoringTargetStage';
 import { Statics } from './statics';
-import { LogQueryAccessRole } from './LogQueryAccessRole';
 
 
 export class MonitoredAccountStack extends Stack {
@@ -22,14 +22,14 @@ export class MonitoredAccountStack extends Stack {
 
     this.addEventSubscriptions(props);
     new DefaultAlarms(this, 'default-alarms');
-    
+
     /**
      * If the account needs to be queried by the log query job (eg. props.queryDefinitons is defined)
      * setup a role to be assumed by the (centralized) log query lambda.
      */
-    if(props.queryDefinitions) {
-      new LogQueryAccessRole(this, 'logqueryrole', { 
-        queryDefinitions: props.queryDefinitions
+    if (props.queryDefinitions) {
+      new LogQueryAccessRole(this, 'logqueryrole', {
+        queryDefinitions: props.queryDefinitions,
       });
     }
 


### PR DESCRIPTION
Moves the role to a separate construct, keeping the stack responsible only for adding constructs/resources.