### PR TITLE
feat: more specific context to message local deploy

### DIFF
--- a/src/OrgtrailMonitorLambda/OrgTrailMonitorHandler.ts
+++ b/src/OrgtrailMonitorLambda/OrgTrailMonitorHandler.ts
@@ -204,7 +204,9 @@ export class OrgTrailMonitorHandler {
    */
   private getUserIdentity(userIdentity: any) {
     if (userIdentity?.type === 'AssumedRole') {
-      return userIdentity.sessionContext?.sessionIssuer?.userName ?? userIdentity.arn;
+      const username = userIdentity.sessionContext?.sessionIssuer?.userName;
+      // Check if username exists and is specific enough, otherwise return arn
+      return username && !username.includes('AWSReservedSSO') ? username : userIdentity.arn;
     }
     if (userIdentity?.type === 'AWSService') {
       return userIdentity.invokedBy;

--- a/src/OrgtrailMonitorLambda/test/orgtrail.test.ts
+++ b/src/OrgtrailMonitorLambda/test/orgtrail.test.ts
@@ -307,6 +307,7 @@ describe('orgtrail', () => {
     const events = convertToLogEvents(generateDataKeyEvent, assumeRoleEvent, retreiveSecretValueEvent) as any;
     await handler.handleLogEvents(events);
     expect(sns.results).toHaveLength(1);
+    expect(sns.results[0].input.Message).toContain('role-name-for-lambda');
   });
 
   test('secret event exclude (global)', async () => {
@@ -374,6 +375,7 @@ describe('orgtrail', () => {
     await handler.handleLogEvents(events);
     expect(sns.results).toHaveLength(1);
     expect(sns.results[0].input.Message).toContain('Local Deployment event detected');
+    expect(sns.results[0].input.Message).toContain('p.ersoon@nijmegen.nl');
   });
   test('pipeline deploy event (global)', async () => {
     const config: Configuration = {


### PR DESCRIPTION
Can be fixed in many different ways. Different method called or even not checking on type.
However, this keeps the identity in context in one central method and tries to prevent impact on existing code and choices.
