### PR TITLE
feat: add eventID to all slack messages to make it easy to lookup in

### DIFF
--- a/src/OrgtrailMonitorLambda/OrgTrailMonitorHandler.ts
+++ b/src/OrgtrailMonitorLambda/OrgTrailMonitorHandler.ts
@@ -37,6 +37,7 @@ export class OrgTrailMonitorHandler {
       const message = this.checkEventAgainstRule(cloudTrailEvent, rule);
       if (message) {
         message.addContext('Account', accountConfiguration?.accountName ?? accountId);
+        message.addContext('eventID', cloudTrailEvent.eventID);
         console.info('Event matched, sending message', JSON.stringify(message, null, 4));
         console.info('Marched rule', JSON.stringify(rule, null, 4));
         await message.publishToPlatformTopic(this.client);

--- a/src/OrgtrailMonitorLambda/test/orgtrail.test.ts
+++ b/src/OrgtrailMonitorLambda/test/orgtrail.test.ts
@@ -376,6 +376,7 @@ describe('orgtrail', () => {
     expect(sns.results).toHaveLength(1);
     expect(sns.results[0].input.Message).toContain('Local Deployment event detected');
     expect(sns.results[0].input.Message).toContain('p.ersoon@nijmegen.nl');
+    expect(sns.results[0].input.Message).toContain('3d659f9e-b0c0-4a95-9d3f-088c3c2cee6e');
   });
   test('pipeline deploy event (global)', async () => {
     const config: Configuration = {


### PR DESCRIPTION
Fixes #

eventID added to all log slack messages to make it easy to look up the specific event

In orgtail gn-mpa, this query gives 0 results for the last weeks:
```
fields @timestamp, @message, @logStream, @log
| sort @timestamp desc
| filter !isPresent(eventID)
| limit 1000
```