### PR TITLE
feat: added three missing accounts in config

### DIFF
--- a/src/DeploymentEnvironments.ts
+++ b/src/DeploymentEnvironments.ts
@@ -387,7 +387,6 @@ export const deploymentEnvironments: { [key: string]: Configuration } = {
       {
         accountName: 'gn-vierdaagsefeesten-accp',
         accountType: 'acceptance',
-        enableDevopsGuru: true,
         env: {
           account: '767397838630',
           region: 'eu-central-1',
@@ -396,7 +395,6 @@ export const deploymentEnvironments: { [key: string]: Configuration } = {
       {
         accountName: 'gn-vierdaagsefeesten-prod',
         accountType: 'production',
-        enableDevopsGuru: true,
         env: {
           account: '637423283365',
           region: 'eu-central-1',

--- a/src/DeploymentEnvironments.ts
+++ b/src/DeploymentEnvironments.ts
@@ -310,6 +310,14 @@ export const deploymentEnvironments: { [key: string]: Configuration } = {
         ],
       },
       {
+        accountName: 'gn-mijn-nijmegen-dev',
+        accountType: 'development',
+        env: {
+          account: '590184009539',
+          region: 'eu-central-1',
+        },
+      },
+      {
         accountName: 'gn-mijn-nijmegen-accp',
         accountType: 'acceptance',
         env: {
@@ -373,6 +381,24 @@ export const deploymentEnvironments: { [key: string]: Configuration } = {
         enableDevopsGuru: true,
         env: {
           account: '887474129159',
+          region: 'eu-central-1',
+        },
+      },
+      {
+        accountName: 'gn-vierdaagsefeesten-accp',
+        accountType: 'acceptance',
+        enableDevopsGuru: true,
+        env: {
+          account: '767397838630',
+          region: 'eu-central-1',
+        },
+      },
+      {
+        accountName: 'gn-vierdaagsefeesten-prod',
+        accountType: 'production',
+        enableDevopsGuru: true,
+        env: {
+          account: '637423283365',
           region: 'eu-central-1',
         },
       },


### PR DESCRIPTION
Fixes #
- Mijn Nijmegen dev
- Vierdaagseaccounts acc & prod

Aanleiding: naam mijn nijmegen dev niet zichtbaar in slack alerts

Andere accounts die er nog niet in staan zijn o.a. backup, irvn-prod en log-archive